### PR TITLE
fix: Remove price per m2 from rental ads

### DIFF
--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -16,6 +16,7 @@ import App from './components/App.vue';
 RR.logInfo('contentscript loaded');
 
 chrome.runtime.sendMessage({ 'switchIconOn': true });
+const POLL_ADDRESS_TIMEOUT = 500;
 
 const initVueTranslations = () => {
   return new Promise((resolve, reject) => {
@@ -66,7 +67,7 @@ const loadPanel = function(address) {
             address,
             details: {
               price: {
-                perSquareMeter: pageDataExtractor.getPrices(window.location.host)
+                perSquareMeter: pageDataExtractor.extractSquarePrice()
               }
             }
           }
@@ -78,7 +79,7 @@ const loadPanel = function(address) {
 let addressOfProperty;
 function initApp() {
   RR.logInfo('Initializing app widget');
-  addressOfProperty = pageDataExtractor.getAddress(window.location.host);
+  addressOfProperty = pageDataExtractor.getAddress();
   RR.logDebug('Address parsed: ', addressOfProperty);
 
   if (RR.String.isNotBlank(addressOfProperty)) {
@@ -94,13 +95,13 @@ function initApp() {
 let pollAddressTimerId;
 function pollAddress() {
   //RR.logDebug('Polling address...'); // you can filter it out in console with regexp filter ^(?=.*?\b.*\b)((?!Poll).)*$ (match all except lines with 'Poll' match)
-  const currentAddressOfProperty = pageDataExtractor.getAddress(window.location.host);
+  const currentAddressOfProperty = pageDataExtractor.getAddress();
   //RR.logDebug('Polled address:', currentAddressOfProperty);
   if (currentAddressOfProperty !== addressOfProperty) {
     $(document).trigger(RR.ADDRESS_CHANGED_EVENT);
     clearTimeout(pollAddressTimerId);
   }
-  pollAddressTimerId = setTimeout(pollAddress, 500);
+  pollAddressTimerId = setTimeout(pollAddress, POLL_ADDRESS_TIMEOUT);
 }
 
 $(document).on(RR.ADDRESS_CHANGED_EVENT, (event) => {

--- a/src/js/sites/index.spec.js
+++ b/src/js/sites/index.spec.js
@@ -25,11 +25,11 @@ describe('extractors', () => {
     });
 
     it('should return price per m2', () => {
-      expect(extractors.getPrices(window.location.host)).to.equal(22222.222222222223);
+      expect(extractors.extractSquarePrice()).to.equal(22222.222222222223);
     });
 
     it('should return address', () => {
-      expect(extractors.getAddress(window.location.host)).to.equal('Komenského, Vlašim, Středočeský kraj');
+      expect(extractors.getAddress()).to.equal('Komenského, Vlašim, Středočeský kraj');
     });
   });
 
@@ -43,11 +43,11 @@ describe('extractors', () => {
     });
 
     it('should return price per m2', () => {
-      expect(extractors.getPrices(window.location.host)).to.equal(57042.25352112676);
+      expect(extractors.extractSquarePrice()).to.equal(57042.25352112676);
     });
 
     it('should return address', () => {
-      expect(extractors.getAddress(window.location.host)).to.equal('Ortenovo náměstí, Praha 7 - Holešovice');
+      expect(extractors.getAddress()).to.equal('Ortenovo náměstí, Praha 7 - Holešovice');
     });
   });
 
@@ -61,11 +61,11 @@ describe('extractors', () => {
     });
 
     it('should return price per m2', () => {
-      expect(extractors.getPrices(window.location.host)).to.equal(64805.194805194806);
+      expect(extractors.extractSquarePrice()).to.equal(64805.194805194806);
     });
 
     it('should return address', () => {
-      expect(extractors.getAddress(window.location.host)).to.equal('Praha - Smíchov Vrázova');
+      expect(extractors.getAddress()).to.equal('Praha - Smíchov Vrázova');
     });
   });
 
@@ -83,11 +83,11 @@ describe('extractors', () => {
     });
 
     it('should return price per m2', () => {
-      expect(extractors.getPrices(window.location.host)).to.equal(31888.88888888889);
+      expect(extractors.extractSquarePrice()).to.equal(31888.88888888889);
     });
 
     it('should return address', () => {
-      expect(extractors.getAddress(window.location.host)).to.equal('Praha 5, Hlubočepy, Machatého');
+      expect(extractors.getAddress()).to.equal('Praha 5, Hlubočepy, Machatého');
     });
   });
 });

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -7,7 +7,14 @@ export const streetNamePredicate = (address) => {
   return address;
 };
 
-export const formatPrice = price => Math.round(price) + ' Kč';
+export const formatPrice = price => {
+  const formatter = new Intl.NumberFormat('cs', {
+    style: 'currency',
+    currency: 'CZK',
+    minimumFractionDigits: 0,
+  });
+  return formatter.format(Math.round(price));
+};
 
 /**
  * Call ga (google analytics) in context of current page - we cannot directly call page functions here

--- a/src/templates/panel.html
+++ b/src/templates/panel.html
@@ -4,7 +4,6 @@
 <!-- Google Analytics from Real Reality Chrome Extension -->
 <script>
   window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-
   ga('create', 'UA-85464417-1', 'auto', 'rr');
   ga('rr.send', 'pageview');
 </script>


### PR DESCRIPTION
Added logic to check if ad is type of RENT and when yes omit price per m2 extraction

Removed location.hostname passing from contentscript to sites

Small refactorings

Fixes #74